### PR TITLE
Fix repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["algebra", "symbolic", "manipulation", "mathematics", "physics"]
 license-file = "License.md"
 name = "symbolica"
 readme = "Readme.md"
-repository = "https://github/benruijl/symbolica"
+repository = "https://github.com/benruijl/symbolica"
 rust-version = "1.73"
 version = "0.3.0"
 


### PR DESCRIPTION
The repository url in the Cargo.toml was broken.