### PR TITLE
corrected docstring of new_vec method: it returns a column vector.

### DIFF
--- a/src/api/python.rs
+++ b/src/api/python.rs
@@ -8743,7 +8743,7 @@ impl PythonMatrix {
         })
     }
 
-    /// Create a new row vector from a list of scalars.
+    /// Create a new column vector from a list of scalars.
     #[classmethod]
     pub fn vec(
         _cls: &PyType,

--- a/src/tensors/matrix.rs
+++ b/src/tensors/matrix.rs
@@ -59,7 +59,7 @@ impl<F: Ring> Matrix<F> {
         m
     }
 
-    /// Create a new row vector from a list of scalars.
+    /// Create a new column vector from a list of scalars.
     pub fn new_vec(data: Vec<F::Element>, field: F) -> Matrix<F> {
         Matrix {
             nrows: data.len() as u32,

--- a/symbolica.pyi
+++ b/symbolica.pyi
@@ -2755,7 +2755,7 @@ class Matrix:
 
     @classmethod
     def vec(cls, entries: Sequence[RationalPolynomial | Polynomial | Expression | int]) -> Matrix:
-        """Create a new row vector from a list of scalars."""
+        """Create a new column vector from a list of scalars."""
 
     @classmethod
     def from_linear(cls, nrows: int, ncols: int, entries: Sequence[RationalPolynomial | Polynomial | Expression | int]) -> Matrix:


### PR DESCRIPTION
The implementation of the `new_vec` method for the `Matrix` struct seems to return a column vector:
```rust
    pub fn new_vec(data: Vec<F::Element>, field: F) -> Matrix<F> {
        Matrix {
            nrows: data.len() as u32,
            ncols: 1,
            data,
            field,
        }
    }
```
However, the original docstring states that the method returns a row vector:
```rust
/// Create a new row vector from a list of scalars.
```
The docstring is therefore updated to
```rust
/// Create a new column vector from a list of scalars.
```