### PR TITLE
Implemented AddAssign, SubAssign and MulAssign traits for Matrix.

### DIFF
--- a/src/tensors/matrix.rs
+++ b/src/tensors/matrix.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Display,
-    ops::{Add, Index, IndexMut, Mul, Neg, Sub},
+    ops::{Add, AddAssign, Index, IndexMut, Mul, MulAssign, Neg, Sub, SubAssign},
     slice::Chunks,
 };
 
@@ -258,6 +258,22 @@ impl<F: Ring> Add<&Matrix<F>> for &Matrix<F> {
     }
 }
 
+impl<F: Ring> AddAssign<&Matrix<F>> for Matrix<F> {
+    ///Add two matrices in place.
+    fn add_assign(&mut self, rhs: &Matrix<F>) {
+        if self.nrows != rhs.nrows || self.ncols != rhs.ncols {
+            panic!(
+                "Cannot add matrices of different dimensions: ({},{}) vs ({},{})",
+                self.nrows, self.ncols, rhs.nrows, rhs.ncols
+            );
+        }
+
+        for (a,b) in self.data.iter_mut().zip(rhs.data.iter()) {
+            self.field.add_assign(a,b);
+        }
+    }
+}
+
 impl<F: Ring> Sub<&Matrix<F>> for &Matrix<F> {
     type Output = Matrix<F>;
 
@@ -276,6 +292,22 @@ impl<F: Ring> Sub<&Matrix<F>> for &Matrix<F> {
         }
 
         m
+    }
+}
+
+impl<F: Ring> SubAssign<&Matrix<F>> for Matrix<F> {
+    ///Add two matrices in place.
+    fn sub_assign(&mut self, rhs: &Matrix<F>) {
+        if self.nrows != rhs.nrows || self.ncols != rhs.ncols {
+            panic!(
+                "Cannot add matrices of different dimensions: ({},{}) vs ({},{})",
+                self.nrows, self.ncols, rhs.nrows, rhs.ncols
+            );
+        }
+
+        for (a,b) in self.data.iter_mut().zip(rhs.data.iter()) {
+            self.field.sub_assign(a,b);
+        }
     }
 }
 
@@ -303,6 +335,14 @@ impl<F: Ring> Mul<&Matrix<F>> for &Matrix<F> {
         }
 
         m
+    }
+}
+
+impl<F: Ring> MulAssign<&Matrix<F>> for Matrix<F> {
+
+    ///Multiply two matrices in place.
+    fn mul_assign(&mut self, rhs: &Matrix<F>) {
+        *self = &*self*rhs;
     }
 }
 
@@ -803,6 +843,11 @@ mod test {
         assert_eq!(c.data, vec![58, 64, 139, 154]);
         assert_eq!(&c[1], &[139, 154]);
         assert_eq!(c[(0, 1)], 64);
+
+        let mut d = a.clone();
+        d+= &a;
+
+        assert_eq!(d.data, vec![2, 4, 6, 8, 10, 12]);
 
         let c_m = c.map(|x| x * 2u64, Z);
         assert_eq!(c_m.data, vec![116, 128, 278, 308]);


### PR DESCRIPTION
This pull request implements the traits `AddAssign`, `SubAssign` and `MulAssign` for the `Matrix` type. Addition and substraction make advantage of the `add_assign` and `sub_assign` methods for rings, while `mul_assign` simply reuses the `mul` method of `Matrix` and is only added for completeness.