### PR TITLE
gitignore and decode for functionmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,16 @@ flake.lock
 flake.nix
 .envrc
 .direnv/
+# Devenv
+#.devenv/
+.devenv*
+devenv.local.nix
+.zed/
+# direnv
+.direnv
+devenv.lock
+devenv.nix
+devenv.yaml
+
+# pre-commit
+.pre-commit-config.yaml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing-subscriber = {version = "0.3.18", features = ["env-filter"]}
 [dependencies]
 ahash = "0.8.7"
 append-only-vec = "0.1"
-bincode = {version = "2.0", optional = true}
+bincode = {version = "2.0", optional = true,features=["derive"]}
 brotli = "5.0"
 byteorder = "1.5"
 bytes = "1.5"


### PR DESCRIPTION
Adds Decode and Encode to FunctionMap. Deriving where I could and explictly implementing where it couldn't.